### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "faker": "^4.1.0",
     "json-schema-faker": "0.5.0-rc15",
     "mongodb": "^3.1.1",
-    "seeder-foreign-keys": "^0.0.2",
+    "seeder-foreign-keys": "^0.1.2",
     "traverse": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Error on install of feathers-plus due to possibly incorrect version of `seeder-foreign-keys`

using command from feathers-plus installation guide:
`npm i -g @feathers-plus/cli`

```
error code ETARGET
error notarget No matching version found for seeder-foreign-keys@^0.0.2
error notarget In most cases you or one of your dependencies are requesting
error notarget a package version that doesn't exist.
error notarget
error notarget It was specified as a dependency of 'json-schema-seeder'
```